### PR TITLE
adding mongocxx

### DIFF
--- a/kinetic/source/Dockerfile
+++ b/kinetic/source/Dockerfile
@@ -28,6 +28,15 @@ RUN apt-get -qq update && \
     #rosdep install -y --from-paths . --ignore-src --rosdistro ${ROS_DISTRO} --as-root=apt:false && \
     rm -rf /var/lib/apt/lists/*
 
+# installing mongocxx driver for the warehouse
+RUN git clone -b 26compat https://github.com/mongodb/mongo-cxx-driver.git && \
+    apt-get update -qq && \
+    apt-get -qq install -y scons && \
+    cd mongo-cxx-driver && \
+    scons --use-system-boost --prefix=/usr/local/ --full --disable-warnings-as-errors && \
+    scons install && \
+    rm -rf /var/lib/apt/lists/*
+
 # HACK, replacing shell with bash for later docker build commands
 RUN mv /bin/sh /bin/sh-old && \
     ln -s /bin/bash /bin/sh


### PR DESCRIPTION
Not really sure whether this should be merged as is. It's more to start a discussion. I'm simply installing the proper mongocxx driver to the kinetic source docker.

To be complete, I could also add the warehouse_ros and warehouse_ros_mongo packages to the workspace, and compile everything (not sure why the current docker source images don't compile the workspace?).

Thoughts?